### PR TITLE
Use CJS for React Native + split optional dependencies loading

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['packages/zstd/**/zstd.ts', 'packages/crypto/**/crypto.ts'],
+    files: ['packages/zstd/**', 'packages/crypto/**'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unsafe-return': 'off',

--- a/packages/anoncreds/package.json
+++ b/packages/anoncreds/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,9 +5,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -10,16 +10,9 @@
     "url": "https://github.com/hiero-ledger/hiero-did-sdk-js/issues"
   },
   "license": "Apache-2.0",
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
-  "types": "./dist/index.d.ts",
-  "browser": "./dist/browser/index.esm.js",
+  "main": "./dist/index.js",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "browser": "./dist/browser/index.esm.js",
-    "require": "./dist/index.cjs.js",
-    "import": "./dist/index.esm.js",
-    "default": "./dist/index.esm.js"
+    "default": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/packages/crypto/src/crypto.ts
+++ b/packages/crypto/src/crypto.ts
@@ -1,4 +1,6 @@
 import { Buffer } from 'buffer';
+import { nodeCrypto } from './node-crypto';
+import { rnCrypto } from './react-native-crypto';
 
 type HashInput = string | Buffer | Uint8Array | ArrayBuffer;
 
@@ -22,21 +24,8 @@ export class Crypto {
 }
 
 function getAvailableCryptoModule(): CryptoModule {
-  // 1. Try to use built-in Node.js crypto module
-  try {
-    const nodeCrypto = require('crypto');
-    if (nodeCrypto.createHash) return nodeCrypto;
-  } catch {
-    // Ignore
-  }
-
-  // 2. Try to use 'react-native-quick-crypto' package (for React Native environments)
-  try {
-    const rnCrypto = require('react-native-quick-crypto');
-    if (rnCrypto.createHash) return rnCrypto;
-  } catch {
-    // Ignore
-  }
+  if (nodeCrypto) return nodeCrypto;
+  else if (rnCrypto) return rnCrypto;
 
   throw new Error(
     "No compatible crypto module found. Please install 'react-native-quick-crypto' or 'crypto' polyfills depending on platform"

--- a/packages/crypto/src/node-crypto.ts
+++ b/packages/crypto/src/node-crypto.ts
@@ -1,0 +1,12 @@
+// Please note that splitting optional dependencies loading to a separate files is done to avoid significant issues with React Native Metro bundler
+// See https://github.com/facebook/metro/issues/836
+
+export let nodeCrypto;
+
+// Try to load built-in Node.js crypto module
+try {
+  const nodeCryptoModule = require('crypto');
+  if (nodeCryptoModule.createHash) nodeCrypto = nodeCryptoModule;
+} catch {
+  // Ignore
+}

--- a/packages/crypto/src/react-native-crypto.ts
+++ b/packages/crypto/src/react-native-crypto.ts
@@ -1,0 +1,12 @@
+// Please note that splitting optional dependencies loading to a separate files is done to avoid significant issues with React Native Metro bundler
+// See https://github.com/facebook/metro/issues/836
+
+export let rnCrypto;
+
+// Try to load 'react-native-quick-crypto' package (for React Native environments)
+try {
+  const rnCryptoModule = require('react-native-quick-crypto');
+  if (rnCryptoModule.createHash) rnCrypto = rnCryptoModule;
+} catch {
+  // Ignore
+}

--- a/packages/crypto/tests/unit/crypto.spec.ts
+++ b/packages/crypto/tests/unit/crypto.spec.ts
@@ -1,10 +1,13 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Crypto } from '@hiero-did-sdk/crypto';
 import { Buffer } from 'buffer';
+import { nodeCrypto } from '../../src/node-crypto';
+import { rnCrypto } from '../../src/react-native-crypto';
 
 const data = 'Test data for sha256 calculating';
 const digest = '952a959a1ac6cd9ce1d80fcd1dfd570401c0d40ab36ea9a7a2e22295fd630d3b';
 
-const engines = [{ name: 'crypto' }, { name: 'react-native-quick-crypto' }];
+const engines = ['crypto', 'react-native-quick-crypto'] as const;
 
 describe('Crypto', () => {
   const mockCreateHash = jest.fn().mockReturnThis();
@@ -16,31 +19,18 @@ describe('Crypto', () => {
     digest: mockDigest,
   };
 
-  beforeEach(() => {
-    jest.mock('crypto', () => undefined);
-    jest.mock('react-native-quick-crypto', () => undefined, { virtual: true });
-    jest.resetModules();
-  });
-
   it('should throw an error if no compatible crypto module is found', () => {
-    // Mock failure for all crypto modules
-    jest.mock('crypto', () => {
-      throw new Error();
-    });
-    jest.mock(
-      'react-native-quick-crypto',
-      () => {
-        throw new Error();
-      },
-      { virtual: true }
-    );
+    // @ts-expect-error Override resolved module
+    nodeCrypto = undefined;
+    // @ts-expect-error Override resolved module
+    rnCrypto = undefined;
 
     expect(() => Crypto.sha256(data)).toThrow('No compatible crypto module found');
   });
 
   it('should handle different types of HashInput', () => {
-    jest.mock('crypto', () => cryptoMock);
-    jest.resetModules();
+    // @ts-expect-error Override resolved module
+    nodeCrypto = cryptoMock;
 
     const stringInput = data;
     const arrayBufferInput = new TextEncoder().encode(data).buffer;
@@ -55,9 +45,18 @@ describe('Crypto', () => {
     expect(mockUpdate).toHaveBeenCalledWith(bufferInput);
   });
 
-  it.each(engines)('should hash a string input correctly using $name', ({ name }) => {
-    jest.mock(name, () => cryptoMock);
-    jest.resetModules();
+  it.each(engines)('should hash a string input correctly using $name', (engine) => {
+    if (engine === 'crypto') {
+      // @ts-expect-error Override resolved module
+      nodeCrypto = cryptoMock;
+      // @ts-expect-error Override resolved module
+      rnCrypto = undefined;
+    } else if (engine === 'react-native-quick-crypto') {
+      // @ts-expect-error Override resolved module
+      nodeCrypto = undefined;
+      // @ts-expect-error Override resolved module
+      rnCrypto = cryptoMock;
+    }
 
     let result = Crypto.sha256(data);
     expect(result).toBe(digest);

--- a/packages/crypto/tsup.config.ts
+++ b/packages/crypto/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'tsup';
 import base from '../../tsup.config';
 
-export default defineConfig(base);
+export default defineConfig({ ...base, entry: ['src/**/*.{ts,tsx}'], bundle: false });

--- a/packages/hcs/package.json
+++ b/packages/hcs/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/hcs/src/shared/mirror-node.ts
+++ b/packages/hcs/src/shared/mirror-node.ts
@@ -4,7 +4,7 @@ import { type Client } from '@hashgraph/sdk';
  * Check the mirror query supported and can be used
  */
 export function isMirrorQuerySupported(client: Client): boolean {
-  return !!client._mirrorNetwork.getNextMirrorNode();
+  return client.constructor.name === 'NodeClient';
 }
 
 /**

--- a/packages/hcs/tests/unit/mirror-node.spec.ts
+++ b/packages/hcs/tests/unit/mirror-node.spec.ts
@@ -2,20 +2,20 @@ import { type Client } from '@hashgraph/sdk';
 import { getMirrorNetworkNodeUrl, isMirrorQuerySupported, normalizeMirrorUrl } from '../../src/shared';
 
 describe('isMirrorQuerySupported', () => {
-  it('returns true when client._mirrorNetwork.getNextMirrorNode returns a value', () => {
+  it('returns true when client.constructor.name is NodeClient', () => {
     const client = {
-      _mirrorNetwork: {
-        getNextMirrorNode: () => 'node1',
+      constructor: {
+        name: 'NodeClient',
       },
     } as unknown as Client;
 
     expect(isMirrorQuerySupported(client)).toBe(true);
   });
 
-  it('returns false when client._mirrorNetwork.getNextMirrorNode returns falsy', () => {
+  it('returns false when client.constructor.name is not a NodeClient', () => {
     const client = {
-      _mirrorNetwork: {
-        getNextMirrorNode: () => null,
+      constructor: {
+        name: 'WebClient',
       },
     } as unknown as Client;
 

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/messages/package.json
+++ b/packages/messages/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/publisher-internal/package.json
+++ b/packages/publisher-internal/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/registrar/package.json
+++ b/packages/registrar/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/signer-hashicorp-vault/package.json
+++ b/packages/signer-hashicorp-vault/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/signer-internal/package.json
+++ b/packages/signer-internal/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/verifier-hashicorp-vault/package.json
+++ b/packages/verifier-hashicorp-vault/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/verifier-internal/package.json
+++ b/packages/verifier-internal/package.json
@@ -14,9 +14,11 @@
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "browser": "./dist/browser/index.esm.js",
+  "react-native": "./dist/browser/index.cjs.js",
   "exports": {
     "types": "./dist/index.d.ts",
     "browser": "./dist/browser/index.esm.js",
+    "react-native": "./dist/browser/index.cjs.js",
     "require": "./dist/index.cjs.js",
     "import": "./dist/index.esm.js",
     "default": "./dist/index.esm.js"

--- a/packages/zstd/package.json
+++ b/packages/zstd/package.json
@@ -10,16 +10,9 @@
     "url": "https://github.com/hiero-ledger/hiero-did-sdk-js/issues"
   },
   "license": "Apache-2.0",
-  "main": "./dist/index.cjs.js",
-  "module": "./dist/index.esm.js",
-  "types": "./dist/index.d.ts",
-  "browser": "./dist/browser/index.esm.js",
+  "main": "./dist/index.js",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "browser": "./dist/browser/index.esm.js",
-    "require": "./dist/index.cjs.js",
-    "import": "./dist/index.esm.js",
-    "default": "./dist/index.esm.js"
+    "default": "./dist/index.js"
   },
   "files": [
     "dist",

--- a/packages/zstd/src/node-zstd.ts
+++ b/packages/zstd/src/node-zstd.ts
@@ -1,0 +1,12 @@
+// Please note that splitting optional dependencies loading to a separate files is done to avoid significant issues with React Native Metro bundler
+// See https://github.com/facebook/metro/issues/836
+
+export let nodeZstd;
+
+// Try to load Node.js 'zstd-napi' package
+try {
+  const nodeZstdModule = require('zstd-napi');
+  if (nodeZstdModule.compress) nodeZstd = nodeZstdModule;
+} catch {
+  // Ignore
+}

--- a/packages/zstd/src/react-native-zstd.ts
+++ b/packages/zstd/src/react-native-zstd.ts
@@ -1,0 +1,20 @@
+// Please note that splitting optional dependencies loading to a separate files is done to avoid significant issues with React Native Metro bundler
+// See https://github.com/facebook/metro/issues/836
+
+import { Buffer } from 'buffer';
+
+export let rnZstd;
+
+// Try to load 'react-native-zstd' package (for React Native environments)
+try {
+  const rnZstdModule = require('react-native-zstd');
+  if (rnZstdModule.compress) {
+    rnZstd = {
+      // Additional data conversion is needed due to inconsistent API between Node and RN implementations
+      compress: (data: Uint8Array): Uint8Array => rnZstdModule.compress(Buffer.from(data).toString()),
+      decompress: (data: Uint8Array): Uint8Array => Uint8Array.from(Buffer.from(rnZstdModule.decompress([...data]))),
+    };
+  }
+} catch {
+  // Ignore
+}

--- a/packages/zstd/src/zstd.ts
+++ b/packages/zstd/src/zstd.ts
@@ -1,4 +1,5 @@
-import { Buffer } from 'buffer';
+import { nodeZstd } from './node-zstd';
+import { rnZstd } from './react-native-zstd';
 
 interface ZstdModule {
   compress(data: Uint8Array): Uint8Array;
@@ -18,26 +19,8 @@ export class Zstd {
 }
 
 function getAvailableZstdModule(): ZstdModule {
-  // 1. Try to use Node.js 'zstd-napi' package
-  try {
-    const nodeZstd = require('zstd-napi');
-    if (nodeZstd) return nodeZstd;
-  } catch {
-    // Ignore
-  }
-
-  // 2. Try to use 'react-native-zstd' package (for React Native environments)
-  try {
-    const rnZstd = require('react-native-zstd');
-    if (rnZstd)
-      return {
-        // Additional data conversion is needed due to inconsistent API between Node and RN implementations
-        compress: (data: Uint8Array): Uint8Array => rnZstd.compress(Buffer.from(data).toString()),
-        decompress: (data: Uint8Array): Uint8Array => Uint8Array.from(Buffer.from(rnZstd.decompress([...data]))),
-      };
-  } catch {
-    // Ignore
-  }
+  if (nodeZstd) return nodeZstd;
+  else if (rnZstd) return rnZstd;
 
   throw new Error(
     "No available zstd module found. Please install 'zstd-napi' or 'react-native-zstd' depending on a platform"

--- a/packages/zstd/tsup.config.ts
+++ b/packages/zstd/tsup.config.ts
@@ -1,4 +1,4 @@
 import { defineConfig } from 'tsup';
 import base from '../../tsup.config';
 
-export default defineConfig(base);
+export default defineConfig({ ...base, entry: ['src/**/*.{ts,tsx}'], bundle: false });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,7 +28,7 @@ const browserOptions: Options = {
   ...commonOptions,
   platform: 'browser',
   outDir: 'dist/browser',
-  format: ['esm'],
+  format: ['cjs', 'esm'],
   inject: ['../../node_modules/node-stdlib-browser/helpers/esbuild/shim.js'],
 };
 


### PR DESCRIPTION
**Description**:
- Updated build and exports configuration to use CJS format for React Native environments
- Split optional dependencies loading in `zstd` and `crypto` packages + disabled bundling
  - See https://github.com/facebook/metro/issues/836

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
