### PR TITLE
Use GH runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: hl-dsdk-js-lin-md
+    runs-on: ubuntu-latest
     name: Release
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
**Description**:
Updated release GH Action workflow to use GH runners instead of self-hosted one.

**Related issue(s)**: #54 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
