### PR TITLE
Fix changes-awaiter timeout diagnostics by surfacing last polling error

### DIFF
--- a/packages/hcs/src/shared/changes-awaiter.ts
+++ b/packages/hcs/src/shared/changes-awaiter.ts
@@ -15,6 +15,7 @@ export async function waitForChangesVisibility<T>(options: {
   const { fetchFn, checkFn, waitTimeout } = options;
   const timeout = waitTimeout ?? DEFAULT_TIMEOUT;
   const startTime = Date.now();
+  let lastError: unknown;
 
   while (Date.now() - startTime < timeout) {
     try {
@@ -22,12 +23,15 @@ export async function waitForChangesVisibility<T>(options: {
       if (checkFn(data)) {
         return;
       }
-    } catch {
-      // Ignore
+    } catch (error) {
+      // Keep the most recent polling failure to improve timeout diagnostics.
+      lastError = error;
     }
 
     await new Promise((resolve) => setTimeout(resolve, POLLING_INTERVAL));
   }
 
-  throw new Error(`Timeout of ${timeout}ms exceeded while waiting for changes visibility`);
+  throw lastError !== undefined
+    ? new Error(`Timeout of ${timeout}ms exceeded while waiting for changes visibility`, { cause: lastError })
+    : new Error(`Timeout of ${timeout}ms exceeded while waiting for changes visibility`);
 }

--- a/packages/hcs/tests/unit/changes-awaiter.spec.ts
+++ b/packages/hcs/tests/unit/changes-awaiter.spec.ts
@@ -1,0 +1,74 @@
+import { waitForChangesVisibility } from '../../src/shared/changes-awaiter';
+
+describe('waitForChangesVisibility', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves when checkFn passes', async () => {
+    const fetchFn = vi.fn().mockResolvedValue('ready');
+    const checkFn = vi.fn((value: string) => value === 'ready');
+
+    await expect(
+      waitForChangesVisibility({
+        fetchFn,
+        checkFn,
+        waitTimeout: 1000,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(checkFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws timeout error without cause when polling does not fail', async () => {
+    const fetchFn = vi.fn().mockResolvedValue('pending');
+    const checkFn = vi.fn(() => false);
+
+    const waitPromise = waitForChangesVisibility({
+      fetchFn,
+      checkFn,
+      waitTimeout: 1000,
+    });
+    const handledPromise = waitPromise.catch((err) => err as Error & { cause?: unknown });
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    const error = await handledPromise;
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('Timeout of 1000ms exceeded while waiting for changes visibility');
+    expect(error.cause).toBeUndefined();
+  });
+
+  it('throws timeout error with the last polling error as cause', async () => {
+    const firstError = new Error('503 Service Unavailable');
+    const secondError = new Error('429 Too Many Requests');
+
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(firstError)
+      .mockRejectedValueOnce(secondError)
+      .mockRejectedValue(secondError);
+
+    const waitPromise = waitForChangesVisibility({
+      fetchFn,
+      checkFn: () => false,
+      waitTimeout: 1000,
+    });
+    const handledPromise = waitPromise.catch((err) => err as Error & { cause?: unknown });
+
+    await vi.advanceTimersByTimeAsync(1500);
+
+    const error = await handledPromise;
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe('Timeout of 1000ms exceeded while waiting for changes visibility');
+    expect(error.cause).toBe(secondError);
+    expect(Object.prototype.propertyIsEnumerable.call(error, 'cause')).toBe(false);
+  });
+});


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog.
-->

Improve debugging experience when visibility polling times out by preserving the last polling failure instead of returning only a generic timeout.

* Track the most recent polling error during retries in `changes-awaiter`
* Attach the last observed polling error as timeout cause when `waitForChangesVisibility` expires
* Add focused unit tests for success, timeout-without-error, and timeout-with-last-error-cause behavior
* Keep existing polling and retry behavior unchanged


**Related issue(s)**:

Fixes #56


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Unit tests were added for the new timeout-cause behavior and run locally.

Command used:
```
pnpm --filter @hiero-did-sdk/hcs exec vitest run tests/unit/changes-awaiter.spec.ts
```


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)