### PR TITLE
docs: add class diagrams for HCS integration package

### DIFF
--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-cache-service-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-cache-service-class-diagram.puml
@@ -1,0 +1,15 @@
+@startuml
+class HcsCacheService {
+  - cache: Cache
+  + constructor(configOrCache: CacheConfig | Cache)
+  + getTopicInfo(client: Client, topicId: string): Promise<TopicInfo | null>
+  + setTopicInfo(client: Client, topicId: string, topicInfo: TopicInfo): Promise<void>
+  + removeTopicInfo(client: Client, topicId: string): Promise<void>
+  + getTopicMessages(client: Client, topicId: string): Promise<TopicMessageData[] | null>
+  + setTopicMessages(client: Client, topicId: string, messages: TopicMessageData[]): Promise<void>
+  + removeTopicMessages(client: Client, topicId: string): Promise<void>
+  + getTopicFile(client: Client, topicId: string): Promise<Buffer | null>
+  + setTopicFile(client: Client, topicId: string, file: Buffer): Promise<void>
+  + removeTopicFile(client: Client, topicId: string): Promise<void>
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-file-service-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-file-service-class-diagram.puml
@@ -1,0 +1,9 @@
+@startuml
+class HcsFileService {
+  - cacheService?: HcsCacheService
+  - client: Client
+  + constructor(client: Client, cache?: CacheConfig | Cache | HcsCacheService)
+  + submitFile(props: SubmitFileProps): Promise<string>
+  + resolveFile(props: ResolveFileProps): Promise<Buffer>
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-message-service-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-message-service-class-diagram.puml
@@ -1,0 +1,9 @@
+@startuml
+class HcsMessageService {
+  - cacheService?: HcsCacheService
+  - client: Client
+  + constructor(client: Client, cache?: CacheConfig | Cache | HcsCacheService)
+  + submitMessage(props: SubmitMessageProps): Promise<SubmitMessageResult>
+  + getTopicMessages(props: GetTopicMessagesProps): Promise<TopicMessageData[]>
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-topic-service-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/hcs-topic-service-class-diagram.puml
@@ -1,0 +1,11 @@
+@startuml
+class HcsTopicService {
+  - cacheService?: HcsCacheService
+  - client: Client
+  + constructor(client: Client, cache?: CacheConfig | Cache | HcsCacheService)
+  + createTopic(props?: CreateTopicProps): Promise<string>
+  + updateTopic(props: UpdateTopicProps): Promise<void>
+  + deleteTopic(props: DeleteTopicProps): Promise<void>
+  + getTopicInfo(props: GetTopicInfoProps): Promise<TopicInfo>
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/hcs-cache-service-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/hcs-cache-service-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a detailed API reference for the `HcsCacheService` class — a service responsible for caching Hedera Consensus Service (HCS) topic information, messages, and files.
 
+== Class Diagram
+
+The class diagram below illustrates the public API of the `HcsCacheService` class.
+
+image::hcs-cache-service-class-diagram.png[]
+
 == Constructor
 
 === `constructor`

--- a/docs/modules/ROOT/pages/03-implementation/components/hcs-file-service-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/hcs-file-service-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a detailed API reference for the `HcsFileService` class — a service for submitting and resolving Hedera Consensus Service (HCS) files following the HCS-1 standard.
 
+== Class Diagram
+
+The class diagram below illustrates the public API of the `HcsFileService` class.
+
+image::hcs-file-service-class-diagram.png[]
+
 == Constructor
 
 === `constructor`

--- a/docs/modules/ROOT/pages/03-implementation/components/hcs-message-service-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/hcs-message-service-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a detailed API reference for the `HcsMessageService` class — a service for submitting and querying messages in Hedera Consensus Service (HCS) topics.
 
+== Class Diagram
+
+The class diagram below illustrates the public API of the `HcsMessageService` class.
+
+image::hcs-message-service-class-diagram.png[]
+
 == Constructor
 
 === `constructor`

--- a/docs/modules/ROOT/pages/03-implementation/components/hcs-service-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/hcs-service-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a concise API reference for the `HederaHcsService` class — a service for working with Hedera Consensus Service (HCS). It enables creation, update, deletion of topics, message submission, and file handling.
 
+== Class Diagram
+
+The class diagram below illustrates the service composition of the HCS integration package.
+
+image::hcs-service-diagram.png[]
+
 == Constructor
 
 === `constructor`

--- a/docs/modules/ROOT/pages/03-implementation/components/hcs-topic-service-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/hcs-topic-service-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a detailed API reference for the `HcsTopicService` class — a service for managing Hedera Consensus Service (HCS) topics, including creating, updating, deleting topics, and retrieving topic info.
 
+== Class Diagram
+
+The class diagram below illustrates the public API of the `HcsTopicService` class.
+
+image::hcs-topic-service-class-diagram.png[]
+
 == Сonstructor
 
 === `constructor`


### PR DESCRIPTION
## Description

Add PlantUML class diagrams for all HCS integration package classes, following the existing pattern used by `Signer` and `Publisher` diagrams.

### New diagrams
- `hcs-topic-service-class-diagram.puml` — HcsTopicService (topic CRUD)
- `hcs-message-service-class-diagram.puml` — HcsMessageService (message submission/retrieval)
- `hcs-file-service-class-diagram.puml` — HcsFileService (HCS-1 file submit/resolve)
- `hcs-cache-service-class-diagram.puml` — HcsCacheService (topic info, message, and file caching)

### Updated API docs
Added `== Class Diagram` sections with `image::` references to:
- `hcs-service-api.adoc`
- `hcs-topic-service-api.adoc`
- `hcs-message-service-api.adoc`
- `hcs-file-service-api.adoc`
- `hcs-cache-service-api.adoc`

Closes #30