### PR TITLE
docs: add class diagrams for utility packages

### DIFF
--- a/docs/modules/ROOT/pages/03-implementation/components/cache-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/cache-api.adoc
@@ -2,6 +2,12 @@
 
 This document provides a detailed API reference for the `LRUMemoryCache` class — an in-memory Least Recently Used (LRU) cache implementation of the `Cache` interface.
 
+== Class Diagram
+
+The class diagram below illustrates the `LRUMemoryCache` and its `Cache` interface.
+
+image::cache-class-diagram.png[]
+
 == Interfaces
 
 === `Cache`

--- a/docs/modules/ROOT/pages/03-implementation/components/client-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/client-api.adoc
@@ -1,6 +1,12 @@
 = HederaClientService API Reference
 
-This document provides a detailed API reference for the `HederaClientService` class — a service to manage Hedera SDK clients with support for multiple Hedera networks (mainnet, testnet, previewnet, local-node, and custom networks).
+This document provides a detailed API reference for the `HederaClientService` — a utility for managing Hedera SDK client connections across multiple configured networks.
+
+== Class Diagram
+
+The class diagram below illustrates the public API of the `HederaClientService` class.
+
+image::client-class-diagram.png[]
 
 == Constants
 

--- a/docs/modules/ROOT/pages/03-implementation/components/crypto-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/crypto-api.adoc
@@ -1,6 +1,12 @@
 = Crypto API Reference
 
-This document provides a concise API reference for the `Crypto` class and its related interfaces, which provide cryptographic hashing functionality, specifically SHA-256 hashing, with compatibility across Node.js and React Native environments.
+This document provides an API reference for the `Crypto` utility class — a cross-platform cryptographic helper that transparently supports both Node.js and React Native environments.
+
+== Class Diagram
+
+The class diagram below illustrates the public API of the `Crypto` utility.
+
+image::crypto-class-diagram.png[]
 
 == Types and Interfaces
 

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/cache-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/cache-class-diagram.puml
@@ -1,0 +1,19 @@
+@startuml
+class LRUMemoryCache {
+  - _maxSize: number
+  - _cache: Map<string, CacheEntry<unknown>>
+  + constructor(maxSize?: number)
+  + get<CacheValue>(key: string): Promise<CacheValue | null>
+  + set<CacheValue>(key: string, value: CacheValue, expiresInSeconds?: number): Promise<void>
+  + remove(key: string): Promise<void>
+  + clear(): Promise<void>
+}
+
+interface Cache {
+  + get<T>(key: string): Promise<T | null>
+  + set<T>(key: string, value: T, expiresInSeconds?: number): Promise<void>
+  + remove(key: string): Promise<void>
+}
+
+LRUMemoryCache ..|> Cache : implements
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/client-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/client-class-diagram.puml
@@ -1,0 +1,8 @@
+@startuml
+class HederaClientService {
+  - configuration: HederaClientConfiguration
+  + constructor(config: HederaClientConfiguration)
+  + getClient(networkName?: string): Client
+  + withClient<T>(props: NetworkName, operation: (client: Client) => Promise<T>): Promise<T>
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/crypto-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/crypto-class-diagram.puml
@@ -1,0 +1,5 @@
+@startuml
+class Crypto {
+  + {static} sha256(data: HashInput): string
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/diagrams/zstd-class-diagram.puml
+++ b/docs/modules/ROOT/pages/03-implementation/components/diagrams/zstd-class-diagram.puml
@@ -1,0 +1,6 @@
+@startuml
+class Zstd {
+  + {static} compress(data: Uint8Array): Uint8Array
+  + {static} decompress(data: Uint8Array): Uint8Array
+}
+@enduml

--- a/docs/modules/ROOT/pages/03-implementation/components/zstd-api.adoc
+++ b/docs/modules/ROOT/pages/03-implementation/components/zstd-api.adoc
@@ -1,6 +1,12 @@
 = Zstd API Reference
 
-This document provides a concise API reference for the `Zstd` class and the related `ZstdModule` interface, which provide compression and decompression functionality using the Zstandard (zstd) algorithm, with support for both Node.js and React Native environments.
+This document provides an API reference for the `Zstd` utility class — a cross-platform Zstandard compression/decompression helper that transparently supports both Node.js and React Native environments.
+
+== Class Diagram
+
+The class diagram below illustrates the public API of the `Zstd` utility.
+
+image::zstd-class-diagram.png[]
 
 == Interfaces
 


### PR DESCRIPTION
## Description

Add PlantUML class diagrams for utility package classes (Client, Cache, Crypto, Zstd), following the existing pattern used by `Signer` and `Publisher` diagrams.

### New diagrams
- `client-class-diagram.puml` — HederaClientService (network client management)
- `cache-class-diagram.puml` — LRUMemoryCache with Cache interface
- `crypto-class-diagram.puml` — Crypto (cross-platform SHA-256 hashing)
- `zstd-class-diagram.puml` — Zstd (cross-platform compression/decompression)

### Updated API docs
Added `== Class Diagram` sections with `image::` references to:
- `client-api.adoc`
- `cache-api.adoc`
- `crypto-api.adoc`
- `zstd-api.adoc`

Closes #31
