### PR TITLE
fix: used GitHub-hosted runner for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    name: Release
+  ci:
+    name: Build & Test
+    runs-on: hl-dsdk-js-lin-md
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -27,6 +27,47 @@ jobs:
 
       - name: Set up Node and install dependencies
         uses: ./.github/actions/setup-npm-env
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test:ci
+
+  release:
+    name: Release & Publish
+    needs: ci
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC (trusted publishing)
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up pnpm
+        uses: step-security/action-setup@3d419c73e38e670dbffe349ffff26dd13c164640 # v4.2.0
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org/'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
 
       # Trusted publishing feature requires NPM 11.5.1+
       - name: Upgrade NPM version to 11+


### PR DESCRIPTION
This updates the release workflow to fix npm publishing when using trusted publishing.
Previously, the workflow was running entirely on a self-hosted runner, which is not supported by npm trusted publishing. To address this, the release process has been split into two jobs.
The CI job continues to run on the existing self-hosted runner and handles build and test steps.
The release job now runs on a GitHub-hosted runner (ubuntu-latest), which is required for trusted publishing. It sets up Node.js and pnpm explicitly, installs dependencies, and rebuilds the packages before publishing.
OIDC-based authentication is enabled by adding the required permissions, so there is no need to use npm tokens.
This keeps the existing workflow mostly unchanged while making the publish step work reliably.
Let me know if you'd prefer a different approach that better fits the current setup.