### PR TITLE
fix(client,hcs): replace internal SDK subpath import with public Client

### DIFF
--- a/packages/client/src/hedera-client-service.ts
+++ b/packages/client/src/hedera-client-service.ts
@@ -1,5 +1,4 @@
 import { Client, Hbar } from '@hiero-ledger/sdk';
-import NodeClient from '@hiero-ledger/sdk/lib/client/NodeClient';
 import { HederaClientConfiguration } from './hedera-client.configuration';
 
 const MAX_TRANSACTION_FEE = 2;
@@ -32,7 +31,7 @@ export class HederaClientService {
 
     if (!networkConfig) throw new Error('Unknown Hedera network');
 
-    let client: NodeClient;
+    let client: Client;
     if (typeof networkConfig.network === 'string') {
       client = Client.forName(networkConfig.network, { scheduleNetworkUpdate: false });
       client.setOperator(networkConfig.operatorId, networkConfig.operatorKey);

--- a/packages/hcs/src/shared/mirror-node.ts
+++ b/packages/hcs/src/shared/mirror-node.ts
@@ -1,9 +1,8 @@
-import { type Client } from '@hiero-ledger/sdk';
-import NodeClient from '@hiero-ledger/sdk/lib/client/NodeClient';
+import { Client } from '@hiero-ledger/sdk';
 
 /**
  * Check the mirror query supported and can be used
  */
 export function isMirrorQuerySupported(client: Client): boolean {
-  return client instanceof NodeClient;
+  return client instanceof Client;
 }

--- a/packages/hcs/tests/unit/mirror-node.spec.ts
+++ b/packages/hcs/tests/unit/mirror-node.spec.ts
@@ -1,18 +1,15 @@
-import NodeClient from '@hiero-ledger/sdk/lib/client/NodeClient';
 import { isMirrorQuerySupported } from '../../src/shared';
+import { Client } from '@hiero-ledger/sdk';
 
 describe('isMirrorQuerySupported', () => {
   it('returns true for a NodeClient instance', () => {
-    const client = NodeClient.forTestnet();
-
+    const client = Client.forTestnet();
     expect(isMirrorQuerySupported(client)).toBe(true);
-
     client.close();
   });
 
   it('returns false for a non-NodeClient object', () => {
     const client = Object.create(null);
-
     expect(isMirrorQuerySupported(client)).toBe(false);
   });
 });


### PR DESCRIPTION
**Description**:
Fix `ERR_PACKAGE_PATH_NOT_EXPORTED` runtime error caused by importing `NodeClient` 
via an internal subpath of `@hiero-ledger/sdk` that is not part of its public exports map.

* Replace `import NodeClient from '@hiero-ledger/sdk/lib/client/NodeClient'` with 
  `import { Client } from '@hiero-ledger/sdk'` in `hedera-client-service.ts`
* Replace internal `NodeClient` type annotation with `Client` in `hedera-client-service.ts`
* Replace `instanceof NodeClient` with `instanceof Client` in `mirror-node.ts`
* Update `mirror-node.spec.ts` to use `Client.forTestnet()` instead of `NodeClient.forTestnet()`

**Related issue(s)**:
Fixes #65

**Notes for reviewer**:
Verified fails without the fix (`ERR_PACKAGE_PATH_NOT_EXPORTED`) and passes with it.
`mirror-node.spec.ts` unit tests remain green. `NodeClient` is already re-exported 
publicly as `Client` from the root of `@hiero-ledger/sdk` — no behavior change.

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)